### PR TITLE
Save input to local storage

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,6 +185,8 @@
             <label class="form-label" for="message">Message</label>
             <textarea id="message" placeholder="Write your message here" maxlength="500" required></textarea>
             <input type="submit" class="submit" value="Get in touch"/>
+            <!--Reset Button-->
+            <input type="reset" id="reset" class="reset" value="Reset"/>
             <!--Error text-->
             <p class="render isHidden">Error</p>
         </form>

--- a/index.js
+++ b/index.js
@@ -257,3 +257,46 @@ function submitForm() {
 }
 
 submitForm();
+
+// Use local storage to save user input.
+const name = document.getElementById('name');
+const email = document.getElementById('email');
+const message = document.getElementById('message');
+
+// Get user input from local storage input object and set it to the form
+function getUserInput() {
+  const input = JSON.parse(localStorage.getItem('input'));
+  if (input) {
+    name.value = input.name;
+    email.value = input.email;
+    message.value = input.message;
+  }
+}
+
+// Save user input to local storage in an object
+function saveInput() {
+  const input = {
+    name: name.value,
+    email: email.value,
+    message: message.value,
+  };
+  localStorage.setItem('input', JSON.stringify(input));
+}
+
+// Call getInput function
+getUserInput();
+
+// When the user changes the content of any input field, the data is saved to the local storage.
+name.addEventListener('input', saveInput);
+email.addEventListener('input', saveInput);
+message.addEventListener('input', saveInput);
+
+// Remove local storage when reset button is clicked
+function resetForm() {
+  const resetButton = document.getElementById('reset');
+  resetButton.addEventListener('click', () => {
+    localStorage.removeItem('input');
+  });
+}
+
+resetForm();

--- a/style.css
+++ b/style.css
@@ -477,10 +477,56 @@
     cursor: pointer;
   }
 
+  .reset {
+    width: 50%;
+    border-radius: 10px;
+    border: 1px solid red;
+    padding: 10px;
+    color: red;
+    margin-top: 10px;
+    background: white;
+    font-weight: bold;
+    font-size: medium;
+    cursor: pointer;
+  }
+
+  .resset:hover {
+    background: red;
+    color: white;
+  }
+
   .submit:hover {
     background: #394ae5;
     color: white;
     border: white solid 1px;
+  }
+
+  .error {
+    color: white;
+    background-color: red;
+    font-size: 1em;
+    margin-left: 406px;
+    margin-right: 406px;
+    margin-bottom: 10px;
+    padding: 10px;
+    display: flex;
+    justify-content: center;
+    border-radius: 15px;
+    box-shadow: 0 0 10px 0 rgb(255, 255, 255);
+  }
+
+  .success {
+    color: white;
+    background-color: green;
+    font-size: 1em;
+    margin-left: 406px;
+    margin-right: 406px;
+    margin-bottom: 10px;
+    padding: 10px;
+    display: flex;
+    justify-content: center;
+    border-radius: 15px;
+    box-shadow: 0 0 10px 0 rgb(255, 255, 255);
   }
 }
 
@@ -894,6 +940,25 @@
     font-weight: bold;
     font-size: medium;
     cursor: pointer;
+  }
+
+  .reset {
+    border-radius: 10px;
+    border: 1px solid red;
+    padding: 20px;
+    color: red;
+    margin-top: 10px;
+    margin-left: 406px;
+    margin-right: 406px;
+    background: white;
+    font-weight: bold;
+    font-size: medium;
+    cursor: pointer;
+  }
+
+  .reset:hover {
+    background-color: red;
+    color: white;
   }
 
   input:focus {


### PR DESCRIPTION
### Preserve Data
In this pull request, the following was handled:
- [x] Add success and error classes in mobile media query in `style.css`
- [x] Add reset button to handle resetting `form` and `localStorage` data
- [x] Add event listener to store every input to `localStorage` object
- [x] Load localStorage data to form `onLoad` if it exists